### PR TITLE
Item13335: apply .spec files when saving configuration

### DIFF
--- a/core/lib/Foswiki/Configure/Load.pm
+++ b/core/lib/Foswiki/Configure/Load.pm
@@ -143,14 +143,11 @@ sub readConfig {
     # Old configs might not bootstrap the OS settings, so set if needed.
     _workOutOS() unless ( $Foswiki::cfg{OS} && $Foswiki::cfg{DetailedOS} );
 
-    my @files = qw( Foswiki.spec LocalSite.cfg );
-    if ($noLocal) {
-        pop @files;
+    my @files;
+    unless ($nospec) {
+        push @files, 'Foswiki.spec';
     }
-    if ($nospec) {
-        shift @files;
-    }
-    elsif ($config_spec) {
+    if (!$nospec && $config_spec) {
         foreach my $dir (@INC) {
             foreach my $subdir ( 'Foswiki/Plugins', 'Foswiki/Contrib' ) {
                 my $d;
@@ -169,6 +166,9 @@ sub readConfig {
                 closedir($d);
             }
         }
+    }
+    unless ($noLocal) {
+        push @files, 'LocalSite.cfg';
     }
 
     for my $file (@files) {

--- a/core/lib/Foswiki/Configure/Wizards/Save.pm
+++ b/core/lib/Foswiki/Configure/Wizards/Save.pm
@@ -223,8 +223,8 @@ sub save {
     else {
         %Foswiki::cfg = ();
 
-        # Read without expansions and without the .spec
-        Foswiki::Configure::Load::readConfig( 1, 1 );
+        # Read without expansions but with the .spec
+        Foswiki::Configure::Load::readConfig( 1, 0, 1 );
     }
 
     # Get changes from 'set' *without* expanding values.


### PR DESCRIPTION
Previously, .spec files would only be applied during bootstrapping. This means
that when users install extensions after bootstrapping, it is difficult to
apply the extension's Config.spec file.

In order to make this work, the order in which Foswiki::Configure::Load reads
the files needed to change: previously, Config.spec files were applied after
applying LocalSite.cfg, thus overriding the values stored there. The new code
loads the files in the following order: Foswiki.spec, Config.spec files,
LocalSite.cfg.