### PR TITLE
This fixes an error occuring when an extension wants to install mime.…

### DIFF
--- a/core/lib/Foswiki/Configure/Package.pm
+++ b/core/lib/Foswiki/Configure/Package.pm
@@ -904,6 +904,7 @@ sub _install {
         # copy the file directly.
         if (
             $file =~ m/^data/    # File for the data directory
+            && ( $file !~ m/^data\/mime.types$/ )
             && $Foswiki::Plugins::SESSION
             && (
                 -e "$target,v"         # rcs history file exists
@@ -1604,7 +1605,7 @@ sub _parseManifest {
     my $ttopic  = '';
     my $tattach = '';
 
-    if ( $file =~ m/^data\/.*/ ) {
+    if ( ( $file =~ m/^data\/.*/ ) && ( $file !~ m/^data\/mime.types$/ ) )  {
         ( $tweb, $ttopic ) = $file =~ m/^data\/(.*)\/(.*?).txt$/;
         unless ( defined $tweb
             && defined $ttopic


### PR DESCRIPTION
This fixes an error occuring during installation when an extension tries to install data/mime.types.

The Package.pm probably needs some additional work, as the data directory is hardcoded and there are quite a lot of corner cases to be dealt with (e.g. we probably do not want an extension to overwrite .htpasswd, but a .changes file might be valid).