### PR TITLE
Item14055: recalculate filesize after beforeUploadHandler

### DIFF
--- a/core/lib/Foswiki/Meta.pm
+++ b/core/lib/Foswiki/Meta.pm
@@ -2946,6 +2946,11 @@ sub attach {
             seek( $opts{stream}, 0, 0 );    # seek to beginning
             binmode( $opts{stream} );
 
+            # recalculate filesize as beforeUploadHandler may have modified the content
+            if (defined $opts{filesize}) {
+                $opts{filesize} = (stat($attrs->{stream}))[7];
+            }
+
             $handlers_called = 1;
         }
 


### PR DESCRIPTION
Plugins can modify the file/stream's content of uploaded/attached files (according to the API docu in Foswiki::Plugins::EmptyPlugin). Hence, we need to recalculate the filesize after the handler(s) have been called.