### PR TITLE
Add systemd service file

### DIFF
--- a/FastCGIEngineContrib/tools/systemd/foswiki-fastcgi.service
+++ b/FastCGIEngineContrib/tools/systemd/foswiki-fastcgi.service
@@ -1,0 +1,43 @@
+# SystemD start file for Foswiki
+#
+# Note that you need to replace the path in 'WorkingDirectory' 
+# to suite your needs if you don't use the default path
+# as there is no variable substitution possible for that setting
+
+[Unit]
+Description=Foswiki
+
+[Service]
+Environment=FOSWIKI_ROOT=/var/www/foswiki
+Environment=FOSWIKI_FCGI=foswiki.fcgi
+Environment=FOSWIKI_BIND=127.0.0.1:9000
+Environment=FOSWIKI_CHILDREN=3
+Environment=FOSWIKI_MAX_REQUESTS=-1
+Environment=FOSWIKI_MAX_SIZE=250000
+Environment=FOSWIKI_CHECK_SIZE=10
+Environment=FOSWIKI_QUIET=true
+Environment=FOSWIKI_PIDFILE=/var/run/foswiki.pid
+
+# Optional, overrides settings above
+EnvironmentFile=-/etc/default/foswiki
+
+# Doesn't seem to support variable substitution. Should be ${FOSWIKI_ROOT}/bin/
+WorkingDirectory=/var/www/foswiki/bin/
+
+# Starts foswiki fcgi service
+ExecStart=/usr/bin/perl ${FOSWIKI_ROOT}/bin/${FOSWIKI_FCGI} \
+        -n $FOSWIKI_CHILDREN \
+        -l $FOSWIKI_BIND \
+        -p $FOSWIKI_PIDFILE \
+        -c $FOSWIKI_CHECK_SIZE \
+        -x $FOSWIKI_MAX_REQUESTS \
+        -s $FOSWIKI_MAX_SIZE \
+        -d
+
+Type=forking
+PIDFile=$FOSWIKI_PIDFILE
+Restart=always
+SyslogIdentifier=foswiki
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Adds systemd service file to start up foswiki automatically. 

Note that the user still has to replace the value for 'WorkingDirectory' as that setting does not support variable substitution.
A work around could be that we start a script that starts foswiki.fcgi in the right working directory.