### PR TITLE
Item14530: Add new config "RootDir" to unify configuartions of file system paths

### DIFF
--- a/core/lib/Foswiki.spec
+++ b/core/lib/Foswiki.spec
@@ -132,36 +132,41 @@ $Foswiki::cfg{PermittedRedirectHostUrls} = '';
 # ---++ File System Paths
 # Configure the file system locations of key Foswiki directories here.  These are usually guessed 
 # correctly during bootstrap. Other file locations are configured within their related sections.
+
+# **PATH LABEL="Root Directory" FEEDBACK="icon='ui-icon-check';label='Validate Permissions'; method='validate_permissions';title='Validate file permissions. WARNING: this may take a long time on a large system'" CHECK="noemptyok perms:r,'*'" **
+# This is the root file system path where all Foswiki directories should be placed.
+# $Foswiki::cfg{RootDir} = '/home/httpd/foswiki';
+
 # **PATH LABEL="Script Directory" FEEDBACK="icon='ui-icon-check';label='Validate Permissions'; method='validate_permissions';title='Validate file permissions.'" CHECK="noemptyok perms:Dx,'(.txt|.cfg)$'" **
 # This is the file system path used to access the Foswiki bin directory.
-# $Foswiki::cfg{ScriptDir} = '/home/httpd/foswiki/bin';
+# $Foswiki::cfg{ScriptDir} = '$Foswiki::cfg{RootDir}/bin';
 
 # **PATH LABEL="Pub Directory" FEEDBACK="icon='ui-icon-check';label='Validate Permissions'; method='validate_permissions';title='Validate file permissions. WARNING: this may take a long time on a large system'" CHECK="noemptyok perms:r,'*',wDn,'(,v|,pfv)$'" **
 # Attachments store (file path, not URL), must match the attachments URL
 # path =/foswiki/pub= - for example =/usr/local/foswiki/pub=  This directory is
 # normally accessible from the web.
-# $Foswiki::cfg{PubDir} = '/home/httpd/foswiki/pub';
+# $Foswiki::cfg{PubDir} = '$Foswiki::cfg{RootDir}/pub';
 
 # **PATH LABEL="Data Directory" FEEDBACK="icon='ui-icon-check';label='Validate Permissions'; method='validate_permissions';title='Validate file permissions. WARNING: this may take a long time on a large system'" CHECK="noemptyok perms:rwDnpd,'(,v|,pfv)$',r" **
 # Topic files store (file path, not URL). For example =/usr/local/foswiki/data=.
 # This directory must not be web accessible. 
-# $Foswiki::cfg{DataDir} = '/home/httpd/foswiki/data';
+# $Foswiki::cfg{DataDir} = '$Foswiki::cfg{RootDir}/data';
 
 # **PATH LABEL="Tools Directory" FEEDBACK="icon='ui-icon-check';label='Validate Permissions'; method='validate_permissions'" CHECK="noemptyok perms:rD" **
 # File path to tools directory. For example =/usr/local/foswiki/tools=.
 # This directory must not be web accessible.
-# $Foswiki::cfg{ToolsDir} = '/home/httpd/foswiki/tools';
+# $Foswiki::cfg{ToolsDir} = '$Foswiki::cfg{RootDir}/tools';
 
 # **PATH LABEL="Template Directory" FEEDBACK="icon='ui-icon-check';label='Validate Permissions'; method='validate_permissions'" CHECK="noemptyok perms:rD" **
 # File path to templates directory. For example =/usr/local/foswiki/templates=.
 # This directory must not be web accessible.
-# $Foswiki::cfg{TemplateDir} = '/home/httpd/foswiki/templates';
+# $Foswiki::cfg{TemplateDir} = '$Foswiki::cfg{RootDir}/templates';
 
 # **PATH LABEL="Locales Directory" FEEDBACK="icon='ui-icon-check';label='Validate Permissions'; method='validate_permissions'" CHECK="noemptyok perms:rD" **
 # File path to locale directory.
 # For example =/usr/local/foswiki/locale=.
 # This directory must not be web accessible.
-# $Foswiki::cfg{LocalesDir} = '/home/httpd/foswiki/locale';
+# $Foswiki::cfg{LocalesDir} = '$Foswiki::cfg{RootDir}/locale';
 
 # **PATH LABEL="Working Directory" ONSAVE FEEDBACK="icon='ui-icon-check';label='Validate Permissions'; method='validate_permissions'" CHECK="noemptyok perms:rw,'[\//]README$',r" **
 # Directory where Foswiki stores files that are required for the management
@@ -185,7 +190,7 @@ $Foswiki::cfg{PermittedRedirectHostUrls} = '';
 #    * ={WorkingDir}/registration_approvals= - this is used by the
 #      default Foswiki registration process to store registrations that
 #      are pending verification.
-# $Foswiki::cfg{WorkingDir} = '/home/httpd/foswiki/working';
+# $Foswiki::cfg{WorkingDir} = '$Foswiki::cfg{RootDir}/working';
 
 # **PATH LABEL="Safe PATH" CHECK='undefok'**
 # You can override the default PATH setting to control

--- a/core/lib/Foswiki/Configure/Load.pm
+++ b/core/lib/Foswiki/Configure/Load.pm
@@ -197,6 +197,7 @@ CODE
     if ( $^O eq 'MSWin32' ) {
 
         #force paths to use '/'
+        $Foswiki::cfg{RootDir}     =~ s|\\|/|g;
         $Foswiki::cfg{PubDir}      =~ s|\\|/|g;
         $Foswiki::cfg{DataDir}     =~ s|\\|/|g;
         $Foswiki::cfg{ToolsDir}    =~ s|\\|/|g;

--- a/core/lib/Foswiki/Configure/Wizards/Save.pm
+++ b/core/lib/Foswiki/Configure/Wizards/Save.pm
@@ -211,6 +211,7 @@ sub save {
     }
 
     my %save;
+    my %set = %{ $this->param('set') };
 
     # Clear out the configuration and re-initialize it either
     # with or without the .spec expansion.  This also clears the
@@ -222,8 +223,13 @@ sub save {
         foreach my $key ( @{ $Foswiki::cfg{BOOTSTRAP} } ) {
             eval("(\$save$key)=\$Foswiki::cfg$key=~m/^(.*)\$/");
             ASSERT( !$@, $@ ) if DEBUG;
-            delete $Foswiki::cfg{BOOTSTRAP};
         }
+        delete $Foswiki::cfg{BOOTSTRAP};
+        print STDERR "BSDIRS set = "
+          . Data::Dumper->Dump( [ $Foswiki::cfg{BSDIRS} ] )
+          if TRACE_SAVE;
+        %set = ( %set, %{ $Foswiki::cfg{BSDIRS} } );
+        delete $Foswiki::cfg{BSDIRS};
 
         %Foswiki::cfg = ();
 
@@ -244,8 +250,10 @@ sub save {
 
     # Get changes from 'set' *without* expanding values. this is
     # a cut-down from Foswiki::Configure::Query::_getSetParams
-    if ( $this->param('set') ) {
-        while ( my ( $k, $v ) = each %{ $this->param('set') } ) {
+    if (%set) {
+        print STDERR "Save set = " . Data::Dumper->Dump( [ \%set ] )
+          if TRACE_SAVE;
+        while ( my ( $k, $v ) = each %set ) {
             my $spec = $root->getValueObject($k);
             eval("\$spec->{old_value} = \$Foswiki::cfg$k") if $spec;
             if ( $spec && defined $v && !ref($v) ) {


### PR DESCRIPTION
I propose a new config parameter "RootDir" to have all other dirs set relative
to this RootDir. Their relativity is only set up at bootstrap config, and the
admin can later freely change them to whatever he/she wants.

So the default settings should be: XxxDir = $Foswiki::cfg{RootDir}/xxx, and
RootDir is auto-detected (at bootstrap) to be the root dir of the website.

Known issue: 
- On page configure > General settings > File system paths, the subdirs are sill shown in absolute path with a button "Reset to default value  $Foswiki::cfg{RootDir}/xxx", but the actually values to be saved are in form "$Foswiki::cfg{RootDir}/xxx". To show the correct form on config page, the Query.pm/getspec() should be modified a little bit. 