### PR TITLE
Item14530: Fix Query.pm to show correct "File System Paths"

### DIFF
--- a/core/lib/Foswiki/Configure/Bootstrap.pm
+++ b/core/lib/Foswiki/Configure/Bootstrap.pm
@@ -108,7 +108,10 @@ sub setBootstrap {
 
     $Foswiki::cfg{isBOOTSTRAPPING} = 1;
     push( @{ $Foswiki::cfg{BOOTSTRAP} }, @BOOTSTRAP );
-    push( @{ $Foswiki::cfg{BOOTSTRAP} }, keys %{ $Foswiki::cfg{BSDIRS} } );
+    push(
+        @{ $Foswiki::cfg{BOOTSTRAP} },
+        keys %{ $Foswiki::cfg{BOOTSTRAPDIRS} }
+    );
 }
 
 =begin TML
@@ -269,9 +272,9 @@ EPITAPH
 
     # (At the moment of writing this line,)
     # the line above is the **last expansion of $Foswiki::cfg**
-    $Foswiki::cfg{BSDIRS} = \%bsdirs;
-    print STDERR "AUTOCONFIG BSDIRS: "
-      . Data::Dumper->Dump( [ $Foswiki::cfg{BSDIRS} ] )
+    $Foswiki::cfg{BOOTSTRAPDIRS} = \%bsdirs;
+    print STDERR "AUTOCONFIG BOOTSTRAPDIRS: "
+      . Data::Dumper->Dump( [ $Foswiki::cfg{BOOTSTRAPDIRS} ] )
       if (TRAUTO);
 
     # Detect the OS and DetailedOS

--- a/core/lib/Foswiki/Configure/Query.pm
+++ b/core/lib/Foswiki/Configure/Query.pm
@@ -248,8 +248,9 @@ sub getspec {
         %Foswiki::cfg = %$upper_cfg;
 
         # Reset all bootstrap subdirs to be relative to RootDir
-        foreach my $bsdir ( keys $Foswiki::cfg{BSDIRS} ) {
-            eval "\$Foswiki::cfg$bsdir = \$Foswiki::cfg{BSDIRS}->{'$bsdir'}";
+        foreach my $bsdir ( keys $Foswiki::cfg{BOOTSTRAPDIRS} ) {
+            eval
+"\$Foswiki::cfg$bsdir = \$Foswiki::cfg{BOOTSTRAPDIRS}->{'$bsdir'}";
         }
     }
     Foswiki::Configure::Load::readConfig( 1, 1 );

--- a/core/lib/Foswiki/Configure/Query.pm
+++ b/core/lib/Foswiki/Configure/Query.pm
@@ -244,8 +244,13 @@ sub getspec {
 
         # If we're bootstrapping, retain the values calculated in
         # the bootstrap process. They are almost certainly wrong,
-        # but are a better starting point that the .spec defaults.
+        # but are a better starting point than the .spec defaults.
         %Foswiki::cfg = %$upper_cfg;
+
+        # Reset all bootstrap subdirs to be relative to RootDir
+        foreach my $bsdir ( keys $Foswiki::cfg{BSDIRS} ) {
+            eval "\$Foswiki::cfg$bsdir = \$Foswiki::cfg{BSDIRS}->{'$bsdir'}";
+        }
     }
     Foswiki::Configure::Load::readConfig( 1, 1 );
 

--- a/core/lib/Foswiki/Configure/Wizards/Save.pm
+++ b/core/lib/Foswiki/Configure/Wizards/Save.pm
@@ -225,11 +225,11 @@ sub save {
             ASSERT( !$@, $@ ) if DEBUG;
         }
         delete $Foswiki::cfg{BOOTSTRAP};
-        print STDERR "BSDIRS set = "
-          . Data::Dumper->Dump( [ $Foswiki::cfg{BSDIRS} ] )
+        print STDERR "BOOTSTRAPDIRS set = "
+          . Data::Dumper->Dump( [ $Foswiki::cfg{BOOTSTRAPDIRS} ] )
           if TRACE_SAVE;
-        %set = ( %set, %{ $Foswiki::cfg{BSDIRS} } );
-        delete $Foswiki::cfg{BSDIRS};
+        %set = ( %set, %{ $Foswiki::cfg{BOOTSTRAPDIRS} } );
+        delete $Foswiki::cfg{BOOTSTRAPDIRS};
 
         %Foswiki::cfg = ();
 


### PR DESCRIPTION
- Fix bootstrapping values of $Foswiki::cfg{$bsdir} in function getspec()