### PR TITLE
Changed email address library to Email::Address::XS

### DIFF
--- a/core/data/System/SystemRequirements.txt
+++ b/core/data/System/SystemRequirements.txt
@@ -1,4 +1,4 @@
-%META:TOPICINFO{author="ProjectContributor" date="1519446557" format="1.1" version="1"}%
+%META:TOPICINFO{author="ProjectContributor" date="1525614262" format="1.1" version="1"}%
 %META:TOPICPARENT{name="AdminDocumentationCategory"}%
 ---+ System Requirements
 
@@ -52,7 +52,7 @@ Install apache and rcs: ==apt-get install apache2 rcs==
 | CGI::Session | =libcgi-session-perl= | |
 | Crypt::PasswdMD5 | =libcrypt-passwdmd5-perl= | |
 | Digest::SHA | =libdigest-sha-perl= | *First shipped in perl 5.9.3 |
-| Email::Address | =libemail-address-perl= | |
+| Email::Address::XS | =libemail-address-xs-perl= | |
 | Email::MIME | =libemail-mime-perl=  | |
 | Encode | =libencode-perl= | |
 | Error | =liberror-perl= | |
@@ -120,7 +120,7 @@ Install apache2, rcs, and perl-CPAN
 | CGI::Session | =perl-CGI-Session= | |
 | Crypt::PasswdMD5 | =perl-Crypt-PasswdMD5= | |
 | Digest::SHA | =perl-Digest-SHA= | *First shipped in perl 5.9.3 |
-| Email::Address | =perl-Email-Address= | |
+| Email::Address::XS | =perl-Email-Address-XS= | |
 | Email::MIME | =perl-Email-MIME=  | |
 | Encode | =perl-Encode=  | |
 | Error | =perl-Error= | |
@@ -197,7 +197,7 @@ Install =www-servers/apache=, =dev-vcs/rcs=, and =dev-lang/perl=
 | CGI::Session | =dev-perl/CGI-Session= | |
 | Crypt::PasswdMD5 | =dev-perl/Crypt-PasswdMD5= | |
 | Digest::SHA | | Included with perl |
-| Email::Address | =dev-perl/Email-Address= | |
+| Email::Address::XS | =dev-perl/Email-Address-XS= | |
 | Email::MIME | =dev-perl/Email-MIME= | |
 | Error | =dev-perl/Error= | |
 | Encode | | Included with perl |
@@ -260,7 +260,7 @@ Install =apache24=, =rcs=, and =perl5=
 | CGI::Session | =p5-CGI-Session= | |
 | Crypt::PasswdMD5 | =p5-Crypt-PasswdMD5= | |
 | Digest::SHA | =p5-Digest-SHA= | *First shipped in perl 5.9.3 |
-| Email::Address | =p5-Email-Address=  | |
+| Email::Address::XS | =p5-Email-Address-XS=  | |
 | Email::MIME | =p5-Email-MIME=  | |
 | Encode | =p5-Encode= | |
 | Error | =p5-Error= | |
@@ -325,7 +325,7 @@ If run as root, the modules will be installed in the System perl.   Otherwise th
 | Crypt::PasswdMD5 | |
 | Digest::SHA | Included with perl |
 | Error | |
-| Email::Address | |
+| Email::Address::XS | |
 | Email::MIME | |
 | Encode | |
 | File::Copy::Recursive | |

--- a/core/lib/Foswiki/Contrib/core/DEPENDENCIES
+++ b/core/lib/Foswiki/Contrib/core/DEPENDENCIES
@@ -17,7 +17,7 @@ Crypt::PasswdMD5,>=0,cpan,Required, for admin password hash and .htpasswd encodi
 Crypt::SMIME,>=0,cpan,Optional S/MIME email signing feature.
 Crypt::X509,>=0,cpan,Optional S/MIME email signing feature.
 Convert::PEM,>=0,cpan,Optional S/MIME email signing feature.
-Email::Address,>1.00,cpan,Required for email addresses.
+Email::Address::XS,>1.00,cpan,Required for email addresses.
 Email::MIME,>=1.903,cpan,Required for correct handling of email MIME structure.
 Email::Simple,>=2.206,cpan,Required for compatibility with Email::MIME.
 Encode,>=2.01,cpan,Required for international characters.

--- a/core/lib/Foswiki/Net.pm
+++ b/core/lib/Foswiki/Net.pm
@@ -651,13 +651,13 @@ sub _sendEmailByNetSMTP {
 
     # extract @to from 'To:', 'CC:', 'BCC:'
     foreach my $field (qw(To CC BCC)) {
-        require Email::Address;
+        require Email::Address::XS;
 
 # Remove names part from addresses. I.e. convert "John Smith <jsmith@nowhere.com>"
 # to just jsmith@nowhere.com
         push @to,
           map { $_->address }
-          Email::Address->parse( $header->header_raw($field) );
+          Email::Address::XS->parse( $header->header_raw($field) );
     }
 
     if ( !( scalar(@to) ) ) {


### PR DESCRIPTION
Changed the Perl email address handling library to Email:Address:XS.

The Perl module Email::Address is marked as vulnerable, deprecated, and reaching its end of life:
http://search.cpan.org/perldoc/Email::Address
http://search.cpan.org/dist/Email-Address/Changes
https://svnweb.freebsd.org/ports?view=revision&revision=463752