### PR TITLE
add missing closing =back

### DIFF
--- a/core/tools/dependencies
+++ b/core/tools/dependencies
@@ -79,3 +79,4 @@ If set then all dependencies will be reported, not just missing dependencies.
 
 Information on using this script.
 
+=back


### PR DESCRIPTION
Without this change, the help option for this script currently displays:
```
# ./dependencies --help
tools/dependencies
    Shell interface to the PERLDEPENDENCYREPORT macro. Generates a report of
    missing dependencies.

SYNOPSIS
     tools/dependencies [options]

    Use all to see all dependencies, and not just missing dependencies.

OPTIONS
    all     If set then all dependencies will be reported, not just missing
            dependencies.

    usage   Information on using this script.

POD ERRORS
    Hey! The above document had some coding errors, which are explained
    below:

    Around line 72:
        =over without closing =back

```