### PR TITLE
fixed curl call to get extensions it was moved " https://foswiki.org/…

### DIFF
--- a/core/pseudo-install.pl
+++ b/core/pseudo-install.pl
@@ -1239,7 +1239,7 @@ sub run {
             my $page = 1;
             print "Getting list of Foswiki extensions\n";
             my $list = do_commands(
-                "curl -# http://foswiki.org/Extensions/JsonReport?skin=text");
+                "curl --compressed  -# "https://foswiki.org/Extensions/JsonReport?skin=text");
             $list = JSON::decode_json($list);
             push @modules, map { $_->{name} } @$list;
         }


### PR DESCRIPTION
fixed curl call to get extensions it was moved " https://foswiki.org/Extensions/JsonReport?skin=text" and is now with gzip compressed.The script failed, when i tried to install Foswiki.